### PR TITLE
fix(components.MapPlot): disable double click zoom for MapGL

### DIFF
--- a/src/components/MapPlot.jsx
+++ b/src/components/MapPlot.jsx
@@ -33,7 +33,7 @@ const MapPlot = React.forwardRef((props, ref) => {
         top: _ne.lat,
         bottom: _sw.lat,
         left: _ne.lng,
-        right: _sw.lng 
+        right: _sw.lng
       }
     }
   }))
@@ -57,6 +57,7 @@ const MapPlot = React.forwardRef((props, ref) => {
       mapboxApiAccessToken={TOKEN}
       disableTokenWarning={true}
       onNativeClick={definingPoints && onDefinedPoint}
+      doubleClickZoom={false}
     >
       { running &&
         <LinearProgress color="secondary" />


### PR DESCRIPTION
When double-clicking any point in the map plot, the MapGL component continuously re-renders the viewport until React reaches a maximum render depth. If you watch the reducer for the action `SET_VIEWPORT_STATE`, you'll see it go haywire.

I attempted to move the `viewport` selector to the root component to pass down into the `MapPlot` component but it had no affect.

This temporary fix disables any viewport changing due to double click zooming.

re: https://reactjs.org/docs/error-decoder.html/?invariant=185